### PR TITLE
Create SettingsManager Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ target_link_libraries(jules_data PUBLIC
     Qt6::Sql
 )
 
+# Create jules_core library
+add_library(jules_core STATIC
+    src/core/settings_manager.cpp
+    include/core/settings_manager.h
+)
+target_include_directories(jules_core PUBLIC include)
+target_link_libraries(jules_core PUBLIC Qt6::Core Qt6::Widgets)
+
 add_library(jules_highlighting STATIC
     src/highlighting/syntax_highlighter.cpp
     include/highlighting/syntax_highlighter.h
@@ -175,6 +183,7 @@ add_executable(jules-linux
 
 target_link_libraries(jules-linux PRIVATE
     jules_api
+    jules_core
     jules_data
     jules_highlighting
     jules_ui

--- a/include/core/settings_manager.h
+++ b/include/core/settings_manager.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QObject>
+#include <QSettings>
+#include "core/theme.h"
+
+namespace jules {
+
+class SettingsManager : public QObject {
+    Q_OBJECT
+public:
+    static SettingsManager& instance();
+
+    // API
+    QString apiKey() const;
+    void setApiKey(const QString& key);
+
+    // Appearance
+    Theme theme() const;
+    void setTheme(Theme theme);
+    float activityFontSize() const;
+    void setActivityFontSize(float size);
+    float diffFontSize() const;
+    void setDiffFontSize(float size);
+
+    // General
+    bool notificationsEnabled() const;
+    void setNotificationsEnabled(bool enabled);
+
+    // Persistence
+    void sync();
+
+signals:
+    void themeChanged(Theme theme);
+    void fontSizeChanged();
+    void apiKeyChanged();
+    void notificationsEnabledChanged(bool enabled);
+
+private:
+    SettingsManager(QObject* parent = nullptr);
+    ~SettingsManager() = default;
+
+    QSettings m_settings;
+};
+
+} // namespace jules

--- a/include/core/theme.h
+++ b/include/core/theme.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace jules {
+
+enum class Theme {
+    Light,
+    Dark,
+    System
+};
+
+} // namespace jules

--- a/include/ui/main_window.h
+++ b/include/ui/main_window.h
@@ -5,17 +5,12 @@
 #include <QToolBar>
 #include <QStatusBar>
 #include <QSettings>
+#include "core/theme.h"
 
 namespace jules {
 
 class FlashMessageWidget;
 enum class FlashMessageType;
-
-enum class Theme {
-    Light,
-    Dark,
-    System
-};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT

--- a/src/core/settings_manager.cpp
+++ b/src/core/settings_manager.cpp
@@ -1,0 +1,90 @@
+#include "core/settings_manager.h"
+#include <QtGlobal>
+
+namespace jules {
+
+namespace {
+    // QSettings Keys
+    const QString KEY_API_KEY = QStringLiteral("api/keyEncoded");
+    const QString KEY_THEME = QStringLiteral("appearance/theme");
+    const QString KEY_ACTIVITY_FONT_SIZE = QStringLiteral("appearance/activityFontSize");
+    const QString KEY_DIFF_FONT_SIZE = QStringLiteral("appearance/diffFontSize");
+    const QString KEY_NOTIFICATIONS = QStringLiteral("general/notifications");
+}
+
+SettingsManager& SettingsManager::instance() {
+    static SettingsManager instance;
+    return instance;
+}
+
+SettingsManager::SettingsManager(QObject* parent)
+    : QObject(parent) {}
+
+// API
+QString SettingsManager::apiKey() const {
+    return m_settings.value(KEY_API_KEY, "").toString();
+}
+
+void SettingsManager::setApiKey(const QString& key) {
+    if (apiKey() != key) {
+        m_settings.setValue(KEY_API_KEY, key);
+        emit apiKeyChanged();
+    }
+}
+
+// Appearance
+Theme SettingsManager::theme() const {
+    return static_cast<Theme>(m_settings.value(KEY_THEME, static_cast<int>(Theme::System)).toInt());
+}
+
+void SettingsManager::setTheme(Theme theme) {
+    if (this->theme() != theme) {
+        m_settings.setValue(KEY_THEME, static_cast<int>(theme));
+        emit themeChanged(theme);
+    }
+}
+
+float SettingsManager::activityFontSize() const {
+    return m_settings.value(KEY_ACTIVITY_FONT_SIZE, 12.0f).toFloat();
+}
+
+void SettingsManager::setActivityFontSize(float size) {
+    if (size >= 9.0f && size <= 24.0f) {
+        if (activityFontSize() != size) {
+            m_settings.setValue(KEY_ACTIVITY_FONT_SIZE, size);
+            emit fontSizeChanged();
+        }
+    }
+}
+
+float SettingsManager::diffFontSize() const {
+    return m_settings.value(KEY_DIFF_FONT_SIZE, 11.0f).toFloat();
+}
+
+void SettingsManager::setDiffFontSize(float size) {
+    if (size >= 9.0f && size <= 24.0f) {
+        if (diffFontSize() != size) {
+            m_settings.setValue(KEY_DIFF_FONT_SIZE, size);
+            emit fontSizeChanged();
+        }
+    }
+}
+
+// General
+bool SettingsManager::notificationsEnabled() const {
+    return m_settings.value(KEY_NOTIFICATIONS, true).toBool();
+}
+
+void SettingsManager::setNotificationsEnabled(bool enabled) {
+    if (notificationsEnabled() != enabled) {
+        m_settings.setValue(KEY_NOTIFICATIONS, enabled);
+        emit notificationsEnabledChanged(enabled);
+    }
+}
+
+// Persistence
+void SettingsManager::sync() {
+    m_settings.sync();
+}
+
+} // namespace jules

--- a/src/input/global_hotkey.cpp
+++ b/src/input/global_hotkey.cpp
@@ -497,6 +497,8 @@ bool X11HotkeyBackend::nativeEventFilter(const QByteArray&, void*, qintptr*) {
 
 #else
 
+struct X11HotkeyBackend::Impl {};
+
 X11HotkeyBackend::X11HotkeyBackend(QObject* parent) : GlobalHotkeyBackend(parent) {}
 X11HotkeyBackend::~X11HotkeyBackend() = default;
 bool X11HotkeyBackend::registerHotkey(const HotkeyBinding&) { return false; }

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -106,6 +106,7 @@ MainWindow::MainWindow(QWidget* parent)
     updateEffectiveTheme();
     applyTheme();
     
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     if (QGuiApplication::styleHints()) {
         connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,
                 this, [this]() {
@@ -115,6 +116,7 @@ MainWindow::MainWindow(QWidget* parent)
             }
         });
     }
+#endif
 }
 
 MainWindow::~MainWindow() = default;
@@ -262,10 +264,12 @@ void MainWindow::updateEffectiveTheme() {
 }
 
 bool MainWindow::isSystemDarkMode() const {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
     if (QGuiApplication::styleHints()) {
         auto scheme = QGuiApplication::styleHints()->colorScheme();
         return scheme == Qt::ColorScheme::Dark;
     }
+#endif
     
     QPalette systemPalette = QGuiApplication::palette();
     QColor windowColor = systemPalette.color(QPalette::Window);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,3 +188,17 @@ add_test(NAME wave_widget COMMAND wave_widget_test)
 set_tests_properties(wave_widget PROPERTIES
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
+
+# Settings Manager test executable
+add_executable(settings_manager_test settings_manager_test.cpp)
+target_link_libraries(settings_manager_test PRIVATE
+    gtest
+    gtest_main
+    jules_core
+    jules_ui
+    Qt6::Core
+    Qt6::Test
+)
+target_include_directories(settings_manager_test PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+add_test(NAME settings_manager COMMAND settings_manager_test)

--- a/tests/settings_manager_test.cpp
+++ b/tests/settings_manager_test.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include "core/settings_manager.h"
+
+// Test fixture for SettingsManager
+class SettingsManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Ensure a clean slate for each test
+        QSettings settings;
+        settings.clear();
+        settings.sync();
+    }
+};
+
+TEST_F(SettingsManagerTest, Singleton) {
+    jules::SettingsManager& instance1 = jules::SettingsManager::instance();
+    jules::SettingsManager& instance2 = jules::SettingsManager::instance();
+    ASSERT_EQ(&instance1, &instance2);
+}
+
+TEST_F(SettingsManagerTest, ApiKey) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    ASSERT_EQ(sm.apiKey(), "");
+
+    QSignalSpy spy(&sm, &jules::SettingsManager::apiKeyChanged);
+    sm.setApiKey("test-key");
+    ASSERT_EQ(sm.apiKey(), "test-key");
+    ASSERT_EQ(spy.count(), 1);
+
+    // Setting same key should not emit signal
+    sm.setApiKey("test-key");
+    ASSERT_EQ(spy.count(), 1);
+}
+
+TEST_F(SettingsManagerTest, Theme) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    ASSERT_EQ(sm.theme(), jules::Theme::System);
+
+    QSignalSpy spy(&sm, &jules::SettingsManager::themeChanged);
+    sm.setTheme(jules::Theme::Dark);
+    ASSERT_EQ(sm.theme(), jules::Theme::Dark);
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> arguments = spy.takeFirst();
+    ASSERT_EQ(static_cast<jules::Theme>(arguments.at(0).toInt()), jules::Theme::Dark);
+}
+
+TEST_F(SettingsManagerTest, ActivityFontSize) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    ASSERT_FLOAT_EQ(sm.activityFontSize(), 12.0f);
+
+    QSignalSpy spy(&sm, &jules::SettingsManager::fontSizeChanged);
+    sm.setActivityFontSize(14.0f);
+    ASSERT_FLOAT_EQ(sm.activityFontSize(), 14.0f);
+    ASSERT_EQ(spy.count(), 1);
+
+    // Test validation (invalid size)
+    sm.setActivityFontSize(8.0f);
+    ASSERT_FLOAT_EQ(sm.activityFontSize(), 14.0f); // Should not change
+    ASSERT_EQ(spy.count(), 1); // Signal should not be emitted
+
+    // Test validation (valid size)
+    sm.setActivityFontSize(24.0f);
+    ASSERT_FLOAT_EQ(sm.activityFontSize(), 24.0f);
+    ASSERT_EQ(spy.count(), 2);
+}
+
+TEST_F(SettingsManagerTest, DiffFontSize) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    ASSERT_FLOAT_EQ(sm.diffFontSize(), 11.0f);
+
+    QSignalSpy spy(&sm, &jules::SettingsManager::fontSizeChanged);
+
+    sm.setDiffFontSize(13.0f);
+    ASSERT_FLOAT_EQ(sm.diffFontSize(), 13.0f);
+    ASSERT_EQ(spy.count(), 1);
+
+    // Test validation
+    sm.setDiffFontSize(25.0f);
+    ASSERT_FLOAT_EQ(sm.diffFontSize(), 13.0f); // Should not change
+    ASSERT_EQ(spy.count(), 1);
+}
+
+TEST_F(SettingsManagerTest, Notifications) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    ASSERT_TRUE(sm.notificationsEnabled());
+
+    QSignalSpy spy(&sm, &jules::SettingsManager::notificationsEnabledChanged);
+    sm.setNotificationsEnabled(false);
+    ASSERT_FALSE(sm.notificationsEnabled());
+    ASSERT_EQ(spy.count(), 1);
+    QList<QVariant> arguments = spy.takeFirst();
+    ASSERT_FALSE(arguments.at(0).toBool());
+}
+
+TEST_F(SettingsManagerTest, Persistence) {
+    jules::SettingsManager& sm = jules::SettingsManager::instance();
+    sm.setApiKey("persistent-key");
+    sm.setTheme(jules::Theme::Light);
+    sm.setDiffFontSize(20.0f);
+    sm.sync();
+
+    // Use a separate QSettings object to verify persistence
+    QSettings settings;
+    ASSERT_EQ(settings.value("api/keyEncoded").toString(), "persistent-key");
+    ASSERT_EQ(static_cast<jules::Theme>(settings.value("appearance/theme").toInt()), jules::Theme::Light);
+    ASSERT_FLOAT_EQ(settings.value("appearance/diffFontSize").toFloat(), 20.0f);
+}


### PR DESCRIPTION
This submission creates a new `SettingsManager` class to centralize application settings, including the necessary build system changes and a comprehensive test suite. The implementation follows best practices by separating core logic from the UI and ensuring all new functionality is thoroughly tested.

Fixes #1

---
*PR created automatically by Jules for task [3896258104499406674](https://jules.google.com/task/3896258104499406674) started by @komod0*